### PR TITLE
Initial setup of issue template and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,12 @@
+---
+name: Issue
+about: Create a new issue
+---
+# Problem Statement
+[What needs to be done and why]
+
+# Criteria for Success
+[Measureable outcome if possible]
+
+# Additional Information
+[ways one might accomplish this task, links, documentation, alternatives, etc.]

--- a/.github/ISSUE_TEMPLATE/proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/proposal_template.md
@@ -1,0 +1,10 @@
+---
+name: Proposal
+about: Propose a new feature or some other changes not related to a direct issue
+---
+
+# Proposal
+[What is the idea]
+
+# Rationale
+[Why should this be implemented]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Fixes coderxio/medication-diversification#ISSUE NUMBER
+
+## Explanation
+[What did you change?]
+
+## Rationale
+[Why did you make the changes mentioned above? What alternatives did you consider?]
+
+## Tests
+1. What testing did you do?
+1. Attach testing logs inside a summary block:
+
+<details>
+<summary>testing logs</summary>
+
+```
+
+```
+</details>
+


### PR DESCRIPTION
This PR sets up some initial issue and PR templates. If you look in the `.github/ISSUE_TEMPLATE` dir, there are two markdown files which correspond to the templates. The PR template is in the root of `.github`. These templates are currently being used for the dailymed repo, but can and likely should be adjusted later for this project. 

These markdown template files are used to pre-populate new issues and PRs with basic headers and sections to explain the issue/pr. 