### PR TITLE
Added window query to prefer MIN over IN

### DIFF
--- a/rx_api.py
+++ b/rx_api.py
@@ -22,9 +22,6 @@ rxcui_ndc_match = rxcui_ndc_match.assign(
     + 1
 ).query('rn < 2').drop(columns=['rn'])
 
-
-#TODO: Pandas mugging similar to windows functions
-
 #saves df to csv
 output_df(rxcui_ndc_match)
 


### PR DESCRIPTION
Fixes coderxio/medication-diversification#22

## Explanation
Added window function in Pandas to prefer MIN over IN to keep the granularity of the RxNorm table (hopefully/in general) to NDC level.  One exception may be GPCK/BPCK which may have two IN instead of one MIN, but those are so rare it shouldn't affect the distributions overall.

## Rationale
The granularity was making MEPS distributions not work correctly.  Needed to be NDC level.

## Tests
1. I analyzed the CSV output of the old way and identified that MINs of that subset are always exact combinations of INs + there were duplicate NDCs (3 per IN/IN/MIN, for example)
2. I re-ran and analyzed the CSV output doing it this way and had no duplicate NDCs

Took row count from 2609 (with duplicate NDCs) to 1907 (with no duplicate NDCs).


