### PR TITLE
Meps utils module with get_dataset function

### DIFF
--- a/src/mdt/meps/utils.py
+++ b/src/mdt/meps/utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+from typing import Callable
+import requests
+
+
+def get_dataset(
+        dat_name: str,
+        dest: os.PathLike = Path.cwd(),
+        handler: Callable[[any], None] = None
+):
+    """Get a MEPS Dataset given a dat name + extension
+
+    Args:
+        dat_name (str): MEPS dat file name, ie: h206adat.zip
+        dest (Path): Destination path to save file, defaults to CWD
+        hander (func, optional): Function to bypass CWD save
+    """
+    url = f'https://www.meps.ahrq.gov/mepsweb/data_files/pufs/{dat_name}'
+    response = requests.get(url)
+
+    if handler:
+        return handler(response)
+
+    (dest / url.split('/')[-1]).write_bytes(response.content)
+
+    return response


### PR DESCRIPTION
## Explanation
Added a meps utils.py module to mimic structure of the rxnorm package. Added a get_dataset function similar to the rxnorm package but with an arg to specify which file to download.

## Rationale
Part of restructuring the project into smaller packages. This would allow one to download the dataset locally or consume with a handler

## Tests
1. What testing did you do?
Function executes appropriately when invoked in the python repl

1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```
Python 3.7.4 (default, Oct 24 2019, 20:27:54)
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from mdt.meps.utils import get_dataset
>>> get_dataset('h206adat.zip')
<Response [200]>
>>>

```
</details>

