### PR TITLE
Require Install of requests and pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='1.0.0',
     # description='A sample Python project',  # Optional
     # long_description=long_description,  # Optional
-    # long_description_content_type='text/markdown',  # Optional (see note above)
+    # long_description_content_type='text/markdown',  # Optional
     # url='https://github.com/pypa/sampleproject',  # Optional
     # author='A. Random Developer',  # Optional
     # author_email='author@example.com',  # Optional
@@ -19,13 +19,16 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     python_requires='>=3.6, <4',
-    # install_requires=['peppercorn'],  # Optional
+    install_requires=[
+        'requests',
+        'pandas'
+    ],  # Optional
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     # package_data={  # Optional
     #    'sample': ['package_data.dat'],
-    #},
+    # },
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:


### PR DESCRIPTION
## Explanation
Currently installing MDT does not install additional required dependencies ie requests and pandas. Adjusted `setup.py` to install these when MDT is installed.

## Rationale
Package breaks unless the end user installs requests and pandas independently. Further improvement would be to pin to specific major versions of requests and pandas

## Tests
1. What testing did you do?
- uninstall all deps in a venv
- installed with `pip install -e .` to check if additional deps were added along with MDT
- Reran `run_mdt.py`
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

Pre Install
```
➜ pip list
Package    Version
---------- -------
pip        19.0.3
setuptools 40.8.0
```

Post Install 
```
➜ pip list
Package                   Version   Location
------------------------- --------- -------------------------------------------------------
certifi                   2020.12.5
chardet                   4.0.0
idna                      2.10
medicationDiversification 1.0.0     /Users/yevgeny/workspace/medication-diversification/src
numpy                     1.20.2
pandas                    1.2.4
pip                       19.0.3
python-dateutil           2.8.1
pytz                      2021.1
requests                  2.25.1
setuptools                40.8.0
six                       1.16.0
urllib3                   1.26.4
```

MDT Run
```
➜ python -m mdt.run_mdt
rxnconso table created in DB
rxnrel table created in DB
rxnsat table created in DB
```
</details>