### PR TITLE
Adding Apache 2.0 license.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2021 CodeRx, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Fixes coderxio/medication-diversification#51

## Explanation
Added a `LICENSE.md` file which contains a copy-pasted version of the Apache 2.0 license + 2021 + CodeRx, LLC.

## Rationale
The repo needs to be open source licensed and Apache 2.0 is preferred by Synthea.

## Tests
N/A