### PR TITLE
Add note about required yaml keys to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ This will create:
 
 **Examples:**
 
+**NOTE:** All yaml keys in the default generated settings file must be present even if the key value is empty, this will be adjusted in a future version of MDT to set appropriate default values if a key is omitted.
+```
+rxclass:
+  include:
+    - class_id: R01AD
+      relationship: ATC
+  exclude: <-- Required key, read as an empty array
+    # -
+```
+
 *Corticosteroid medications*
 ```
 rxclass:


### PR DESCRIPTION
Fixes coderxio/medication-diversification#ISSUE NUMBER

## Explanation
Add explanation about required keys in yaml settings

## Rationale
This needs to be adjusted in a future version of MDT to supply defaults when keys are omitted. For now users must leave the keys in the yaml file even if they are empty

</details>

