### PR TITLE
Lowercase lookup table names to resolve glitch when submitting PRs to Synthea

### DIFF
--- a/src/mdt/utils.py
+++ b/src/mdt/utils.py
@@ -518,7 +518,7 @@ def generate_module_json(meps_rxcui_ndc_df, dcp_demographictotal_ingred_remarks_
 
     medication_ingredient_transition_name_list = dcp_demographictotal_ingred_remarks_df['medication_ingredient_name'].apply(lambda x: normalize_name(state_prefix + x)).unique().tolist()
     filename = module_name + ingredient_distribution_suffix
-    lookup_table_name = filename + '.csv'
+    lookup_table_name = filename.lower() + '.csv'
     lookup_table_transition = []
     for idx, transition in enumerate(medication_ingredient_transition_name_list):
         lookup_table_transition.append({
@@ -547,7 +547,7 @@ def generate_module_json(meps_rxcui_ndc_df, dcp_demographictotal_ingred_remarks_
             '-- --------- ----',
         ]
         filename = module_name + '_' + ingredient_name + product_distribution_suffix
-        lookup_table_name = filename + '.csv'
+        lookup_table_name = filename.lower() + '.csv'
         lookup_table_transition = []
 
         medication_product_name_list = dcp_demographictotal_prod_remarks_dict[ingredient_name+'_df_remarks']['medication_product_name'].unique().tolist()

--- a/src/mdt/utils.py
+++ b/src/mdt/utils.py
@@ -517,8 +517,8 @@ def generate_module_json(meps_rxcui_ndc_df, dcp_demographictotal_ingred_remarks_
         ingredient_transition_state_remarks.append(ingredient_detail)
 
     medication_ingredient_transition_name_list = dcp_demographictotal_ingred_remarks_df['medication_ingredient_name'].apply(lambda x: normalize_name(state_prefix + x)).unique().tolist()
-    filename = module_name + ingredient_distribution_suffix
-    lookup_table_name = filename.lower() + '.csv'
+    filename = normalize_name(module_name + ingredient_distribution_suffix, 'lower')
+    lookup_table_name = filename + '.csv'
     lookup_table_transition = []
     for idx, transition in enumerate(medication_ingredient_transition_name_list):
         lookup_table_transition.append({
@@ -546,8 +546,8 @@ def generate_module_json(meps_rxcui_ndc_df, dcp_demographictotal_ingred_remarks_
             '#  [ % pop ] Name',
             '-- --------- ----',
         ]
-        filename = module_name + '_' + ingredient_name + product_distribution_suffix
-        lookup_table_name = filename.lower() + '.csv'
+        filename = normalize_name(module_name + '_' + ingredient_name + product_distribution_suffix, 'lower')
+        lookup_table_name = filename + '.csv'
         lookup_table_transition = []
 
         medication_product_name_list = dcp_demographictotal_prod_remarks_dict[ingredient_name+'_df_remarks']['medication_product_name'].unique().tolist()


### PR DESCRIPTION
Fixes #101 

## Explanation
Changed two lines in utils.py to lowercase the lookup_table_name in the same way we lowercase the .csv files themselves (the lookup tables).

## Rationale
When submitting our first PR (https://github.com/synthetichealth/synthea/pull/1182) to Synthea, the non-lowercase lookup_table_names broke some sort of automated check that happens on all PRs for Synthea.  Changing this still allowed Synthea to work and also will make the PR process smoother in the future.

## Tests
Ran MDT maintenance_inhaler build locally and noted that the lookup_table_names were now all lower_case.
