### PR TITLE
Replace append with pd.concat

### DIFF
--- a/src/mdt/utils.py
+++ b/src/mdt/utils.py
@@ -411,7 +411,7 @@ def generate_module_csv(meps_rxcui_ndc_df, module_name, settings, path=Path.cwd(
         else:
             validation_df_ingred = dcp_demographictotal_prod_df.merge(dcp_demographictotal_ingred_df, how='inner',on='medication_ingredient_name')    
         validation_df_ingred['validation_percent_product_patients'] = validation_df_ingred['percent_ingredient_patients']*validation_df_ingred['percent_product_patients']
-        validation_df = validation_df.append(validation_df_ingred)
+        validation_df = pd.concat([validation_df, validation_df_ingred])
 
     output_df(validation_df, path = path_manager(Path.cwd() / module_name / 'log'), filename = 'validation_df_output')
     


### PR DESCRIPTION
Fixes #100 

## Explanation
On line 414 of utils.py, replaced
`validation_df = validation_df.append(validation_df_ingred)`
with
`validation_df = pd.concat([validation_df, validation_df_ingred])`

Thanks to @yevgenybulochnik and @kristentaytok for the assist with the correct syntax for pd.concat!

## Rationale
We were getting a Future deprecation warning with every run of MDT, which was annoying and eventually would break MDT.  This change fixes the Future error without affecting MDT.

## Tests
I created a dummy module called `concat_test` that was the same config as the `emergency_inhaler` module.  I had already been working with the emergency inhaler module and was familiar with the output from the old .append method.  Once I changed .append to pd.concat, the concat test module had the same output.

See below for the logs for each of those (pre and post change) runs.

<details>
<summary>testing logs</summary>

```
Below is BEFORE the change to pd.concat (i.e. when it was still .append):
======================================================================
  SUBMODULE EMERGENCY INHALER
======================================================================

This submodule prescribes a medication based on population data.

IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.
All medications prescribed in this module are assigned to the attribute
'emergency_inhaler'.

Reference links:
    RxClass: https://mor.nlm.nih.gov/RxClass/
    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html
    RxNav: https://mor.nlm.nih.gov/RxNav/
    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1
    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory

Made with (</>) by the CodeRx Medication Diversification Tool (MDT)

MDT settings for this submodule:
{
    "module": {
        "name": null,
        "assign_to_attribute": null,
        "reason": "asthma_condition",
        "as_needed": true,
        "chronic": true,
        "refills": 0
    },
    "rxclass": {
        "include": null,
        "exclude": null
    },
    "rxcui": {
        "include": [
            "435",
            "237159"
        ],
        "exclude": null
    },
    "ingredient_tty_filter": "IN",
    "dose_form_filter": [
        "Metered Dose Inhaler",
        "Inhalation Solution"
    ],
    "meps": {
        "age_ranges": [
            "0-5",
            "6-103"
        ],
        "demographic_distribution_flags": {
            "age": true,
            "gender": false,
            "state": false
        }
    },
    "state_prefix": "Prescribe_",
    "ingredient_distribution_suffix": "_ingredient_distribution",
    "product_distribution_suffix": "_product_distribution",
    "default_age_ranges": [
        "0-3",
        "4-7",
        "8-11",
        "12-17",
        "18-25",
        "26-35",
        "36-45",
        "46-65",
        "65-103"
    ]
}
======================================================================
 MEDICATION INGREDIENT TABLE TRANSITION                               
======================================================================
Ingredients in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 98.0% ] Albuterol
2. [ 2.0% ] Levalbuterol
======================================================================
 ALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  
======================================================================
Products in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 0.9% ] Albuterol_0_21_Mg_Ml_Inhalation_Solution
2. [ 1.5% ] Albuterol_0_417_Mg_Ml_Inhalation_Solution
3. [ 26.1% ] Albuterol_0_83_Mg_Ml_Inhalation_Solution
4. [ 0.4% ] Albuterol_5_Mg_Ml_Inhalation_Solution
5. [ 2.1% ] Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil
6. [ 34.3% ] Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin
7. [ 0.2% ] Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin
8. [ 34.6% ] Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair
======================================================================
 LEVALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  
======================================================================
Products in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 32.8% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler
2. [ 20.0% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex
3. [ 47.2% ] Levalbuterol_0_417_Mg_Ml_Inhalation_Solution

Below is AFTER the change to pd.concat:
======================================================================
  SUBMODULE CONCAT TEST
======================================================================

This submodule prescribes a medication based on population data.

IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.
All medications prescribed in this module are assigned to the attribute
'concat_test'.

Reference links:
    RxClass: https://mor.nlm.nih.gov/RxClass/
    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html
    RxNav: https://mor.nlm.nih.gov/RxNav/
    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1
    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory

Made with (</>) by the CodeRx Medication Diversification Tool (MDT)

MDT settings for this submodule:
{
    "module": {
        "name": null,
        "assign_to_attribute": null,
        "reason": "asthma_condition",
        "as_needed": true,
        "chronic": true,
        "refills": 0
    },
    "rxclass": {
        "include": null,
        "exclude": null
    },
    "rxcui": {
        "include": [
            "435",
            "237159"
        ],
        "exclude": null
    },
    "ingredient_tty_filter": "IN",
    "dose_form_filter": [
        "Metered Dose Inhaler",
        "Inhalation Solution"
    ],
    "meps": {
        "age_ranges": [
            "0-5",
            "6-103"
        ],
        "demographic_distribution_flags": {
            "age": true,
            "gender": false,
            "state": false
        }
    },
    "state_prefix": "Prescribe_",
    "ingredient_distribution_suffix": "_ingredient_distribution",
    "product_distribution_suffix": "_product_distribution",
    "default_age_ranges": [
        "0-3",
        "4-7",
        "8-11",
        "12-17",
        "18-25",
        "26-35",
        "36-45",
        "46-65",
        "65-103"
    ]
}
======================================================================
 MEDICATION INGREDIENT TABLE TRANSITION                               
======================================================================
Ingredients in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 98.0% ] Albuterol
2. [ 2.0% ] Levalbuterol
======================================================================
 ALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  
======================================================================
Products in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 0.9% ] Albuterol_0_21_Mg_Ml_Inhalation_Solution
2. [ 1.5% ] Albuterol_0_417_Mg_Ml_Inhalation_Solution
3. [ 26.1% ] Albuterol_0_83_Mg_Ml_Inhalation_Solution
4. [ 0.4% ] Albuterol_5_Mg_Ml_Inhalation_Solution
5. [ 2.1% ] Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil
6. [ 34.3% ] Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin
7. [ 0.2% ] Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin
8. [ 34.6% ] Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair
======================================================================
 LEVALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  
======================================================================
Products in lookup table:
#  [ % pop ] Name
-- --------- ----
1. [ 32.8% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler
2. [ 20.0% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex
3. [ 47.2% ] Levalbuterol_0_417_Mg_Ml_Inhalation_Solution
```
</details>

